### PR TITLE
fix: server no longer spins 100% CPU

### DIFF
--- a/teal/server/websockets/connectionHandler.tl
+++ b/teal/server/websockets/connectionHandler.tl
@@ -18,68 +18,80 @@ function ConnectionHandler:onNewWebsocket(_: socket.Client, _: ServerClientRegis
 end
 
 function ConnectionHandler:handleNext(pegasus: Pegasus, handler: Handler, register: ServerClientRegister, frameHandler: FrameHandler)
-    local receivers, senders, err = socket.select(register.receivers, register.senders, 0)
-    if not err then
-        if receivers then
-            for _, receiver in ipairs(receivers) do
-                if (receiver == register.server) then
-                    local client, errmsg = register.server:accept()
+    local register_senders = {}
 
-                    if client then
-                        client:settimeout(pegasus.timeout, 'b')
-                        handler:processRequest(pegasus.port, client, register.server)
-                    elseif errmsg ~= "timeout" then
-                        print("Failed to accept connection "..register.nextIndex..": "..errmsg)
-                    end
+    for client, frames in pairs(register.messageQueue) do
+        if (#frames == 0) then
+            table.insert(register_senders, client)
+        end
+    end
 
-                    if (register:containsClient(client)) then
-                        print("Connection "..register.nextIndex.." converted to a websocket")
-                        client:setoption("keepalive", true)
-                        self:onNewWebsocket(client, register)
-                    else
-                        -- print("Connection "..register.nextIndex.." completed and closed")
-                    end
+    local receivers, senders, err = socket.select(register.receivers, register_senders, nil)
+
+    if err then
+        print("Error: ", err)
+        return
+    end
+
+    if receivers then
+        for _, receiver in ipairs(receivers) do
+            if (receiver == register.server) then
+                local client, errmsg = register.server:accept()
+
+                if client then
+                    client:settimeout(pegasus.timeout, 'b')
+                    handler:processRequest(pegasus.port, client, register.server)
+                elseif errmsg ~= "timeout" then
+                    print("Failed to accept connection "..register.nextIndex..": "..errmsg)
+                end
+
+                if (register:containsClient(client)) then
+                    print("Connection "..register.nextIndex.." converted to a websocket")
+                    client:setoption("keepalive", true)
+                    self:onNewWebsocket(client, register)
                 else
-                    local client = receiver as socket.Client
-                    local index = register.indexMap[client]
-                    local status, result = pcall(function(): Frame
-                        local frame = Frame:readNext(client)
-                        return frame
-                    end)
-                    if (status) then
-                        pcall(function() frameHandler:handleFrame(client, result, register) end)
+                    -- print("Connection "..register.nextIndex.." completed and closed")
+                end
+            else
+                local client = receiver as socket.Client
+                local index = register.indexMap[client]
+                local status, result = pcall(function(): Frame
+                    local frame = Frame:readNext(client)
+                    return frame
+                end)
+                if (status) then
+                    pcall(function() frameHandler:handleFrame(client, result, register) end)
+                else
+                    local containedError = result as ContainedError
+                    if (containedError.message == "closed") then
+                        print("Connection "..index.." forcibly closed.")
+                        register:removeClient(client)
                     else
-                        local containedError = result as ContainedError
-                        if (containedError.message == "closed") then
-                            print("Connection "..index.." forcibly closed.")
-                            register:removeClient(client)
-                        else
-                            print("Error parsing frame from connection "..index..": "..containedError.message)
-                        end
+                        print("Error parsing frame from connection "..index..": "..containedError.message)
                     end
+                end
 
-                    -- Send immediate responses, e.g ping or pong
-                    local immediate = register.immediateMessageQueue[client]
-                    if (immediate ~= nil) then
-                       for _, frame in ipairs(immediate) do
-                          client:send(frame)
-                       end
-                       register.immediateMessageQueue[client] = {}
-                    end
+                -- Send immediate responses, e.g ping or pong
+                local immediate = register.immediateMessageQueue[client]
+                if (immediate ~= nil) then
+                   for _, frame in ipairs(immediate) do
+                      client:send(frame)
+                   end
+                   register.immediateMessageQueue[client] = {}
                 end
             end
         end
-        if senders then
-            for _, client in ipairs(senders) do
-                local index = register.indexMap[client]
-                -- Send non-immediate responses, e.g broadcasts
-                if (index ~= nil) then
-                    for _, frame in ipairs(register.messageQueue[client]) do
-                       client:send(frame)
-                    end
-                    register.messageQueue[client] = {}
-                 end
-            end
+    end
+    if senders then
+        for _, client in ipairs(senders) do
+            local index = register.indexMap[client]
+            -- Send non-immediate responses, e.g broadcasts
+            if (index ~= nil) then
+                for _, frame in ipairs(register.messageQueue[client]) do
+                   client:send(frame)
+                end
+                register.messageQueue[client] = {}
+             end
         end
     end
 


### PR DESCRIPTION
Senders were always ready to send so `perf` showed we were just hammering syscalls polling to send.

We not only check send sockets as ready if there are messages to send.